### PR TITLE
Fix typos.

### DIFF
--- a/latex/acceptors_and_transducers.tex
+++ b/latex/acceptors_and_transducers.tex
@@ -73,9 +73,10 @@ nondeterministic.
 Let's start by constructing some very basic automata to get a feel for their
 various properties.
 
-The start state $s = 0$ has a bold circle around it. The accepting state $1$ is
+In figure~\ref{fig:simple_fsa}, the start state $s = 0$ has a bold circle
+around it. The accepting state $1$ is
 represented with concentric circles. Each arc has a label and a corresponding
-weight. So the first arc from state $0$ to state $1$ with the text $a/0$ means
+weight. So the first arc from state $0$ to state $2$ with the text $a/0$ means
 the label is $a$ and the weight is $0$. The fact that there is only a single
 label on each arc means this graph is an \emph{acceptor}. Since it has weights,
 we say its a weighted acceptor. Since the number of states is finite, some


### PR DESCRIPTION
Also, the following parts can be improved.

(1)
https://github.com/awni/automata_ml/blob/e38946aa53141246946081530472c14987a4b0e4/latex/acceptors_and_transducers.tex#L66-L67

It would be great if you also mention that "there are two arcs leaving the state 0 both with the label $a$"

(2) https://github.com/awni/automata_ml/blob/e38946aa53141246946081530472c14987a4b0e4/latex/acceptors_and_transducers.tex#L186-L188

> For example the graph above

It's less clear which figure "above" refers to. Using `figure~\ref{fig:fsa_loops}` is easier to understand.

> For example the graph above accepts any string that starts with zero 
 or more $a$s and ends in $bb$.

The graph also accepts $a^*cb$, but it is not mentioned in the document.