### PR TITLE
Fix caption error

### DIFF
--- a/latex/basic_operations.tex
+++ b/latex/basic_operations.tex
@@ -280,8 +280,8 @@ figure~\ref{fig:concat_example_inputs}.
         \centering
         \includegraphics[scale=\dotscale]{figures/concat_example_2}
     \end{subfigure}
-    \caption{The acceptor on the right has the language $\{ba, bc\}$, the
-    acceptor on the left has the language $\{a, c\}$.}
+    \caption{The acceptor on the left has the language $\{ba, bc\}$, the
+    acceptor on the right has the language $\{a, c\}$.}
     \label{fig:concat_example_inputs}
 \end{figure}
 


### PR DESCRIPTION
See:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/11765074/177890513-006a2167-ee1b-4d9f-a09a-f26ef4712fab.png">

From Figure 3.13,  the order of graphs are correct.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/11765074/177890542-c156c8ea-4da9-4ef2-81dd-e129f8c978b5.png">
